### PR TITLE
Add hardware_tests to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,7 @@ These changes Fix # | allow the user to | improve | ...
 ### Release planning (please answer)
 - [ ] When is the new feature released?
 - [ ] Which dependent packages do have to be released simultaneously?
+
+### Hardware tests
+_Unstrike the text below to enable automatic hardware tests if available. Otherwise use this as a request for the reviewer._
+- [ ] ~Perform hardware tests~


### PR DESCRIPTION
## Description
This adds a field 

> - [ ] Perform hardware tests

to the PR template.

This string is detected if a instance of https://github.com/PilzDE/pilz_github_ci_runner is running on the respective repo.
If there is no such instance the field still could indicate this to the reviewer that it could be a good idea to test the proposed changes on real hardware.
